### PR TITLE
feat: ローカルSupabase開発環境の設定とGitHub OAuth対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ fix_*.sql
 # Playwright
 test-results/
 playwright-report/
+sub/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,59 @@ gh issue create --repo ksyunnnn/claude --title "[Session Log] <Brief Description
 - `npm run test:e2e` - Run Playwright end-to-end tests
 - `npm run test:e2e:ui` - Run Playwright tests with UI
 
+### Supabase Local Development Commands
+- `npm run db:start` - Start local Supabase services (requires Docker)
+- `npm run db:stop` - Stop local Supabase services
+- `npm run db:status` - Check status of local Supabase services
+- `npm run db:reset` - Reset database (apply all migrations and seed data)
+- `npm run db:migrate` - Create a new migration file
+- `npm run db:studio` - Open Supabase Studio in browser
+- `npm run db:mailbox` - Open Inbucket (local email testing) in browser
+
 ### Development Workflow
 - Use `npm run dev` for development with hot reload enabled
 - Always run `npm run lint` before committing changes
 - The project uses Turbopack for faster development builds
+
+### Local Supabase Development Setup
+
+#### Prerequisites
+- Docker Desktop must be installed and running
+- Supabase CLI installed (currently v2.34.3, update recommended to v2.39.2)
+
+#### Setup Commands
+```bash
+# Start local Supabase services
+supabase start
+
+# Check service status
+supabase status
+
+# Stop services (when done)
+supabase stop
+
+# Reset database (apply migrations and seed data)
+supabase db reset
+```
+
+#### Local Services
+- **API Server**: http://127.0.0.1:54321
+- **Database**: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+- **Studio (Admin)**: http://127.0.0.1:54323
+- **Inbucket (Email Testing)**: http://127.0.0.1:54324
+
+#### Environment Configuration
+For local development, update `.env.local`:
+```bash
+# Supabase - Local Development
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+```
+
+#### Database Management
+- Migrations are automatically applied when starting Supabase
+- Current migrations: initial_schema, fix_rls_policies, create_follows_table, create_likes_table
+- Use Supabase Studio for data visualization and management
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Claude Commandsは、開発者がClaude Code用のカスタムスラッシュコ
 - npm または yarn
 - Supabaseアカウント
 - GitHubアカウント（OAuth用）
+- Docker Desktop（ローカル開発用、オプション）
 
 ### 環境変数の設定
 
@@ -67,6 +68,39 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
    - Client ID: GitHubで取得したOAuth App ID
    - Client Secret: GitHubで取得したOAuth App Secret
    - Redirect URL: `https://your-project.supabase.co/auth/v1/callback`
+
+### ローカル開発環境のセットアップ
+
+Dockerを使用してSupabaseをローカルで実行できます：
+
+```bash
+# Supabase CLIのインストール
+npm install -g supabase
+
+# ローカル環境の起動
+npm run db:start
+
+# ステータス確認
+npm run db:status
+
+# 管理画面を開く
+npm run db:studio
+
+# メールボックス（テスト用）を開く
+npm run db:mailbox
+
+# 環境の停止
+npm run db:stop
+```
+
+#### GitHub OAuth設定（ローカル開発用）
+
+1. [GitHub OAuth App作成手順](docs/github-oauth-setup.md)を参照してOAuth Appを作成
+2. `.env.local`に以下を追加：
+   ```env
+   SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID=your_github_client_id
+   SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET=your_github_client_secret
+   ```
 
 ### データベース設計について
 

--- a/docs/github-oauth-setup.md
+++ b/docs/github-oauth-setup.md
@@ -1,0 +1,86 @@
+# GitHub OAuth App設定ガイド
+
+ローカル開発環境でGitHub認証を使用するための設定手順です。
+
+## 1. GitHub OAuth Appの作成
+
+1. GitHubにログインし、以下のURLにアクセス:
+   https://github.com/settings/developers
+
+2. 左側のメニューから「OAuth Apps」を選択
+
+3. 「New OAuth App」ボタンをクリック
+
+4. 以下の情報を入力:
+
+   ### ローカル開発環境用の設定値
+   
+   - **Application name**: `Claude Commands (Local)`
+   - **Homepage URL**: `http://localhost:3000`
+   - **Application description**: （任意）Local development environment
+   - **Authorization callback URL**: `http://127.0.0.1:54321/auth/v1/callback`
+
+   ⚠️ **重要**: Authorization callback URLは必ず上記の通り設定してください。
+   これはSupabase Auth APIのエンドポイントです。`127.0.0.1`（localhostではない）を使用する必要があります。
+
+5. 「Register application」をクリック
+
+## 2. Client IDとClient Secretの取得
+
+1. 作成されたOAuth Appのページで以下を確認:
+   - **Client ID**: 自動的に表示される（例: `Ov23liABCDEF123456`）
+   
+2. Client Secretを生成:
+   - 「Generate a new client secret」ボタンをクリック
+   - 生成されたSecretをコピー（一度しか表示されません！）
+
+## 3. 環境変数の設定
+
+1. プロジェクトルートの`.env.local`ファイルを開く
+
+2. 以下の環境変数を追加:
+
+```bash
+# GitHub OAuth - Local Development
+SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID=your_client_id_here
+SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET=your_client_secret_here
+```
+
+3. `your_client_id_here`と`your_client_secret_here`を実際の値に置き換える
+
+## 4. Supabaseの再起動
+
+環境変数を設定した後、Supabaseを再起動して設定を反映させます:
+
+```bash
+npm run db:stop
+npm run db:start
+```
+
+## 5. 動作確認
+
+1. `npm run dev`でNext.jsアプリケーションを起動
+2. ブラウザで http://localhost:3000 にアクセス
+3. 「Sign in with GitHub」ボタンをクリック
+4. GitHubの認証ページにリダイレクトされることを確認
+
+## トラブルシューティング
+
+### エラー: "Redirect URI mismatch"
+- GitHub OAuth Appの設定で、Authorization callback URLが正確に設定されているか確認
+- URLは完全一致する必要があります（末尾のスラッシュも含む）
+
+### エラー: "Invalid client_id"
+- 環境変数が正しく設定されているか確認
+- Supabaseを再起動したか確認
+
+### 環境変数が認識されない場合
+- `.env.local`ファイルが正しい場所にあるか確認
+- ファイル名が正確か確認（`.env`ではなく`.env.local`）
+- Supabaseとアプリケーションを両方再起動
+
+## セキュリティに関する注意事項
+
+- **Client Secret**は絶対にGitにコミットしないでください
+- `.env.local`ファイルは`.gitignore`に含まれていることを確認
+- 本番環境では別のOAuth Appを作成し、異なるClient ID/Secretを使用してください

--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
     "start": "next start",
     "lint": "next lint",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "db:start": "supabase start",
+    "db:stop": "supabase stop",
+    "db:status": "supabase status",
+    "db:reset": "supabase db reset",
+    "db:migrate": "supabase migration new",
+    "db:studio": "open http://127.0.0.1:54323",
+    "db:mailbox": "open http://127.0.0.1:54324"
   },
   "dependencies": {
     "@playwright/mcp": "^0.0.35",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -117,7 +117,7 @@ file_size_limit = "50MiB"
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = ["https://127.0.0.1:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
@@ -260,6 +260,14 @@ max_frequency = "5s"
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.github]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID)"
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+
 [auth.external.apple]
 enabled = false
 client_id = ""


### PR DESCRIPTION
- Supabase管理用npmスクリプトを追加（db:start, db:stop, db:status等）
- GitHub OAuth設定ドキュメントを作成
- ローカル開発環境用の設定をCLAUDE.mdとREADMEに追記
- supabase/config.tomlにGitHub OAuth設定を追加
- 正しいredirect_uri（127.0.0.1:54321）の設定手順を文書化

🤖 Generated with Claude Code