### PR TITLE
fix: remotion-demoをTypeScript/ESLintチェックから除外してVercelビルドエラーを解決

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores: ["remotion-demo/**/*", "sub/**/*"]
+  }
 ];
 
 export default eslintConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "remotion-demo", "sub"]
 }


### PR DESCRIPTION
## 問題
Vercelデプロイ時にremotion-demo内のTypeScriptファイルがメインプロジェクトのビルドチェックに含まれ、 @remotion/cli/configモジュールが見つからないエラーが発生

## 解決策
- tsconfig.jsonのexcludeにremotion-demo、subディレクトリを追加
- eslint.config.mjsのignoresにremotion-demo、subディレクトリを追加
- ローカルビルドテスト成功を確認

🤖 Generated with [Claude Code](https://claude.ai/code)