### PR TITLE
feat: SNS共有用のOGP・Twitterカードメタタグ実装

### DIFF
--- a/src/app/[username]/[commandSlug]/opengraph-image.tsx
+++ b/src/app/[username]/[commandSlug]/opengraph-image.tsx
@@ -1,0 +1,242 @@
+import { ImageResponse } from 'next/og'
+import { createClient } from '@/lib/supabase/server'
+import { getUserByIdentifier } from '@/lib/user-utils'
+
+export const runtime = 'edge'
+
+export const alt = 'Command Preview'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+interface Props {
+  params: Promise<{ username: string; commandSlug: string }>
+}
+
+export default async function Image({ params }: Props) {
+  const { username, commandSlug } = await params
+
+  try {
+    const supabase = await createClient()
+    
+    // Get user profile by username or ID
+    const profile = await getUserByIdentifier(username)
+    if (!profile) {
+      return defaultImage()
+    }
+
+    const userId = profile.id
+
+    const { data: command } = await supabase
+      .from('commands')
+      .select(`
+        *,
+        profiles:user_id (
+          username,
+          full_name
+        )
+      `)
+      .eq('user_id', userId)
+      .eq('slug', commandSlug)
+      .single()
+
+    if (!command) {
+      return defaultImage()
+    }
+
+    const authorName = command.profiles?.full_name || command.profiles?.username || 'Anonymous'
+    const commandName = command.name
+    const description = command.description || `A custom slash command by ${authorName}`
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            height: '100%',
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            backgroundColor: 'white',
+            padding: 60,
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              marginBottom: 40,
+            }}
+          >
+            {/* Logo */}
+            <div
+              style={{
+                width: 60,
+                height: 60,
+                backgroundColor: '#4B5563',
+                borderRadius: 12,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginRight: 20,
+              }}
+            >
+              <div
+                style={{
+                  color: 'white',
+                  fontSize: 36,
+                  fontWeight: 'bold',
+                }}
+              >
+                》
+              </div>
+            </div>
+            <div
+              style={{
+                color: '#6B7280',
+                fontSize: 24,
+                fontWeight: 600,
+              }}
+            >
+              Slash Commands
+            </div>
+          </div>
+
+          {/* Main Content */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              width: '100%',
+              flex: 1,
+            }}
+          >
+            <div
+              style={{
+                color: '#1F2937',
+                fontSize: 48,
+                fontWeight: 700,
+                lineHeight: 1.2,
+                marginBottom: 16,
+                maxWidth: '100%',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              /{commandName}
+            </div>
+            
+            <div
+              style={{
+                color: '#6B7280',
+                fontSize: 24,
+                fontWeight: 400,
+                lineHeight: 1.4,
+                marginBottom: 32,
+                maxWidth: '100%',
+                wordBreak: 'break-word',
+              }}
+            >
+              {description.length > 120 ? description.substring(0, 120) + '...' : description}
+            </div>
+
+            <div
+              style={{
+                color: '#9CA3AF',
+                fontSize: 20,
+                fontWeight: 500,
+              }}
+            >
+              by {authorName}
+            </div>
+          </div>
+        </div>
+      ),
+      {
+        ...size,
+      }
+    )
+  } catch (error) {
+    console.error('Error generating command OG image:', error)
+    return defaultImage()
+  }
+}
+
+function defaultImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'white',
+          fontSize: 48,
+          fontWeight: 700,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginBottom: 40,
+          }}
+        >
+          <div
+            style={{
+              width: 80,
+              height: 80,
+              backgroundColor: '#4B5563',
+              borderRadius: 16,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginRight: 24,
+            }}
+          >
+            <div
+              style={{
+                color: 'white',
+                fontSize: 48,
+                fontWeight: 'bold',
+              }}
+            >
+              》
+            </div>
+          </div>
+          <div
+            style={{
+              color: '#1F2937',
+              fontSize: 56,
+              fontWeight: 700,
+            }}
+          >
+            Slash Commands
+          </div>
+        </div>
+        <div
+          style={{
+            color: '#6B7280',
+            fontSize: 28,
+            textAlign: 'center',
+          }}
+        >
+          Command Not Found
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}

--- a/src/app/[username]/[commandSlug]/page.tsx
+++ b/src/app/[username]/[commandSlug]/page.tsx
@@ -10,9 +10,76 @@ import { LikedUsersModal, type LikedUser } from '@/components/liked-users-modal'
 import { getLikeCount, getLikeStatus, getLikedUsers } from '@/lib/actions/like-actions'
 import { isAuthenticated } from '@/lib/auth-utils'
 import { LikeErrorHandler } from '@/components/like-error-handler'
+import type { Metadata } from 'next'
 
 interface CommandPageProps {
   params: Promise<{ username: string; commandSlug: string }>
+}
+
+export async function generateMetadata({ params }: CommandPageProps): Promise<Metadata> {
+  const { username, commandSlug } = await params
+  const supabase = await createClient()
+  
+  // Get user profile by username or ID
+  const profile = await getUserByIdentifier(username)
+  if (!profile) {
+    return {
+      title: 'Command Not Found',
+    }
+  }
+
+  const userId = profile.id
+
+  const { data: command } = await supabase
+    .from('commands')
+    .select(`
+      *,
+      profiles:user_id (
+        username,
+        full_name
+      )
+    `)
+    .eq('user_id', userId)
+    .eq('slug', commandSlug)
+    .single()
+
+  if (!command) {
+    return {
+      title: 'Command Not Found',
+    }
+  }
+
+  const authorName = command.profiles?.full_name || command.profiles?.username || 'Anonymous'
+  const title = `${command.name} by ${authorName} - Slash Commands`
+  const description = command.description || `A custom slash command by ${authorName}`
+  const url = `/${username}/${commandSlug}`
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'Slash Commands',
+      images: [
+        {
+          url: `/opengraph-image?title=${encodeURIComponent(command.name)}&author=${encodeURIComponent(authorName)}&description=${encodeURIComponent(description)}`,
+          width: 1200,
+          height: 630,
+          alt: `${command.name} by ${authorName}`,
+        },
+      ],
+      type: 'article',
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [`/opengraph-image?title=${encodeURIComponent(command.name)}&author=${encodeURIComponent(authorName)}&description=${encodeURIComponent(description)}`],
+    },
+  }
 }
 
 export default async function CommandPage({ params }: CommandPageProps) {

--- a/src/app/[username]/opengraph-image.tsx
+++ b/src/app/[username]/opengraph-image.tsx
@@ -1,0 +1,310 @@
+import { ImageResponse } from 'next/og'
+import { createClient } from '@/lib/supabase/server'
+import { getUserByIdentifier } from '@/lib/user-utils'
+import { getFollowCounts } from '@/lib/actions/follow-actions'
+
+export const runtime = 'edge'
+
+export const alt = 'User Profile'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+interface Props {
+  params: Promise<{ username: string }>
+}
+
+export default async function Image({ params }: Props) {
+  const { username } = await params
+
+  try {
+    const supabase = await createClient()
+    
+    // Get user profile by username or ID
+    const profile = await getUserByIdentifier(username)
+    if (!profile) {
+      return defaultImage()
+    }
+
+    const userId = profile.id
+    
+    // Get follow counts
+    const { followers, following } = await getFollowCounts(userId)
+    
+    // Get command count
+    const { count: commandCount } = await supabase
+      .from('commands')
+      .select('*', { count: 'exact' })
+      .eq('user_id', userId)
+      .eq('is_public', true)
+
+    const userName = profile.full_name || profile.username || 'Anonymous User'
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            height: '100%',
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            backgroundColor: 'white',
+            padding: 60,
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              marginBottom: 40,
+            }}
+          >
+            {/* Logo */}
+            <div
+              style={{
+                width: 60,
+                height: 60,
+                backgroundColor: '#4B5563',
+                borderRadius: 12,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginRight: 20,
+              }}
+            >
+              <div
+                style={{
+                  color: 'white',
+                  fontSize: 36,
+                  fontWeight: 'bold',
+                }}
+              >
+                》
+              </div>
+            </div>
+            <div
+              style={{
+                color: '#6B7280',
+                fontSize: 24,
+                fontWeight: 600,
+              }}
+            >
+              Slash Commands
+            </div>
+          </div>
+
+          {/* Main Content */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              width: '100%',
+              flex: 1,
+            }}
+          >
+            <div
+              style={{
+                color: '#1F2937',
+                fontSize: 48,
+                fontWeight: 700,
+                lineHeight: 1.2,
+                marginBottom: 24,
+                maxWidth: '100%',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {userName}
+            </div>
+            
+            {/* Stats */}
+            <div
+              style={{
+                display: 'flex',
+                gap: 40,
+                marginBottom: 32,
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div
+                  style={{
+                    color: '#1F2937',
+                    fontSize: 32,
+                    fontWeight: 700,
+                  }}
+                >
+                  {commandCount || 0}
+                </div>
+                <div
+                  style={{
+                    color: '#6B7280',
+                    fontSize: 18,
+                    fontWeight: 500,
+                  }}
+                >
+                  Commands
+                </div>
+              </div>
+              
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div
+                  style={{
+                    color: '#1F2937',
+                    fontSize: 32,
+                    fontWeight: 700,
+                  }}
+                >
+                  {followers}
+                </div>
+                <div
+                  style={{
+                    color: '#6B7280',
+                    fontSize: 18,
+                    fontWeight: 500,
+                  }}
+                >
+                  Followers
+                </div>
+              </div>
+              
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div
+                  style={{
+                    color: '#1F2937',
+                    fontSize: 32,
+                    fontWeight: 700,
+                  }}
+                >
+                  {following}
+                </div>
+                <div
+                  style={{
+                    color: '#6B7280',
+                    fontSize: 18,
+                    fontWeight: 500,
+                  }}
+                >
+                  Following
+                </div>
+              </div>
+            </div>
+
+            <div
+              style={{
+                color: '#9CA3AF',
+                fontSize: 20,
+                fontWeight: 500,
+              }}
+            >
+              @{profile.username || 'user'}
+            </div>
+          </div>
+        </div>
+      ),
+      {
+        ...size,
+      }
+    )
+  } catch (error) {
+    console.error('Error generating user OG image:', error)
+    return defaultImage()
+  }
+}
+
+function defaultImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'white',
+          fontSize: 48,
+          fontWeight: 700,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginBottom: 40,
+          }}
+        >
+          <div
+            style={{
+              width: 80,
+              height: 80,
+              backgroundColor: '#4B5563',
+              borderRadius: 16,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginRight: 24,
+            }}
+          >
+            <div
+              style={{
+                color: 'white',
+                fontSize: 48,
+                fontWeight: 'bold',
+              }}
+            >
+              》
+            </div>
+          </div>
+          <div
+            style={{
+              color: '#1F2937',
+              fontSize: 56,
+              fontWeight: 700,
+            }}
+          >
+            Slash Commands
+          </div>
+        </div>
+        <div
+          style={{
+            color: '#6B7280',
+            fontSize: 28,
+            textAlign: 'center',
+          }}
+        >
+          User Not Found
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,29 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Slash Commands - Share Custom Slash Commands",
   description: "Share and discover custom slash commands for Claude Code",
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'),
+  openGraph: {
+    title: "Slash Commands - Share Custom Slash Commands",
+    description: "Share and discover custom slash commands for Claude Code",
+    url: '/',
+    siteName: 'Slash Commands',
+    images: [
+      {
+        url: '/opengraph-image',
+        width: 1200,
+        height: 630,
+        alt: 'Slash Commands',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: "Slash Commands - Share Custom Slash Commands",
+    description: "Share and discover custom slash commands for Claude Code",
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function RootLayout({

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,88 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+
+export const alt = 'Slash Commands'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'white',
+          fontSize: 48,
+          fontWeight: 700,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginBottom: 40,
+          }}
+        >
+          {/* Double Chevron Logo */}
+          <div
+            style={{
+              width: 80,
+              height: 80,
+              backgroundColor: '#4B5563',
+              borderRadius: 16,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginRight: 24,
+            }}
+          >
+            <div
+              style={{
+                color: 'white',
+                fontSize: 48,
+                fontWeight: 'bold',
+                display: 'flex',
+              }}
+            >
+              》
+            </div>
+          </div>
+          <div
+            style={{
+              color: '#1F2937',
+              fontSize: 56,
+              fontWeight: 700,
+            }}
+          >
+            Slash Commands
+          </div>
+        </div>
+        <div
+          style={{
+            color: '#6B7280',
+            fontSize: 28,
+            textAlign: 'center',
+            maxWidth: 800,
+            lineHeight: 1.3,
+          }}
+        >
+          Share and discover custom slash commands for Claude Code
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}


### PR DESCRIPTION
## 概要
SNSでのリンク共有時に適切なプレビューカードが表示されるよう、OGP（Open Graph Protocol）メタタグとTwitterカード設定を実装しました。

## 実装内容

### メタタグ設定
- **Root Layout**: 基本的なOGPメタタグとTwitterカード設定を追加
- **動的メタデータ生成**: コマンドページとユーザープロフィールページで個別のメタデータを動的生成
- **metadataBase設定**: 環境変数を使用した適切なベースURL設定

### OGP画像生成機能
- **Next.js ImageResponse API**を使用したエッジ実行環境での高速画像生成
- **サイト共通画像** (`src/app/opengraph-image.tsx`)
- **コマンドページ用動的画像** (`src/app/[username]/[commandSlug]/opengraph-image.tsx`)
  - コマンド名、作者名、説明を含む専用レイアウト
- **ユーザープロフィール用動的画像** (`src/app/[username]/opengraph-image.tsx`)
  - ユーザー名、コマンド数、フォロワー数、フォロー数を含む統計情報表示

### デザイン統一
- 既存のブランドアイデンティティを継承（#4B5563カラー、ダブルシェブロンロゴ）
- Apple風フラットデザインスタイルを維持
- 1200x630px（OGP推奨サイズ）での画像生成

## 対応プラットフォーム
- X/Twitter（summary_large_image形式）
- Facebook/Meta
- Discord  
- LinkedIn
- その他OGP対応SNS全般

## 技術詳細
- **Edge Runtime**: 高速な画像生成のためのエッジ実行環境使用
- **TypeScript**: 完全な型安全性を保持
- **エラーハンドリング**: データ取得失敗時のフォールバック画像生成

## テスト
- ✅ ESLintチェック通過
- ✅ TypeScriptビルド成功
- ✅ 全ページでのメタタグ設定確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)